### PR TITLE
feat(localdate): 添加双重访问器、时区支持及 API 增强

### DIFF
--- a/src/dbt/adapters/hologres/local_date.py
+++ b/src/dbt/adapters/hologres/local_date.py
@@ -14,6 +14,49 @@ from typing import Union
 import calendar
 
 
+class DualAccessor:
+    """
+    Descriptor that allows a property to be accessed both as an attribute and as a method.
+
+    Example:
+        obj.year      # Returns the year (int)
+        obj.year()    # Also returns the year (int)
+    """
+    def __init__(self, getter):
+        self.getter = getter
+        self.__name__ = getter.__name__
+        self.__doc__ = getter.__doc__
+
+    def __get__(self, obj, objtype=None):
+        if obj is None:
+            return self
+
+        # Get the value
+        value = self.getter(obj)
+
+        # Create a callable that returns the value
+        def callable_method():
+            return value
+
+        # Copy docstring and make it look like a method
+        callable_method.__doc__ = self.__doc__
+        callable_method.__name__ = self.__name__
+
+        # Return the callable (which when called returns value, but itself represents the value)
+        # For int values, we need to make the callable behave like an int
+        class CallableValue(int):
+            """An int subclass that is also callable."""
+            def __new__(cls, val, original_callable):
+                obj = int.__new__(cls, val)
+                obj._original_callable = original_callable
+                return obj
+
+            def __call__(self):
+                return int(self)
+
+        return CallableValue(value, callable_method)
+
+
 class LocalDate:
     """
     A date class supporting chainable operations for Jinja2 templates.
@@ -42,144 +85,159 @@ class LocalDate:
     
     @staticmethod
     def _parse_date_string(date_str: str) -> date:
-        """Parse date string in various formats."""
+        """
+        Parse date string in various formats.
+
+        Supports:
+        - ISO 8601 with timezone (e.g., 2024-01-15T10:30:00+08:00, 2024-12-31T23:59:59Z)
+        - ISO 8601 without timezone (e.g., 2024-01-15T10:30:00)
+        - Standard date formats (e.g., 2024-01-15, 2024/01/15, 20240115)
+        - Datetime formats (e.g., 2024-01-15 10:30:00)
+        """
         date_str = date_str.strip()
-        
-        # Try common date formats
+
+        # Try ISO 8601 format first (handles timezone-aware strings)
+        # Replace 'Z' suffix with '+00:00' for Python 3.7+ fromisoformat compatibility
+        try:
+            return datetime.fromisoformat(date_str.replace('Z', '+00:00')).date()
+        except (ValueError, AttributeError):
+            pass
+
+        # Try common date/datetime formats
         formats = [
             "%Y-%m-%d",           # 2024-01-15
             "%Y/%m/%d",           # 2024/01/15
             "%Y%m%d",             # 20240115
-            "%Y-%m-%dT%H:%M:%S",  # ISO format with time
+            "%Y-%m-%dT%H:%M:%S",  # ISO format with time (no timezone)
             "%Y-%m-%d %H:%M:%S",  # datetime format
         ]
-        
+
         for fmt in formats:
             try:
                 return datetime.strptime(date_str, fmt).date()
             except ValueError:
                 continue
-        
+
         raise ValueError(f"Cannot parse date string: {date_str}")
     
     # ========== Subtraction Methods ==========
     
-    def sub_days(self, days: int) -> "LocalDate":
+    def sub_days(self, days: int = 1) -> "LocalDate":
         """
         Subtract days from this date.
-        
+
         Args:
-            days: Number of days to subtract
-            
+            days: Number of days to subtract (default: 1)
+
         Returns:
             New LocalDate instance
         """
         new_date = self._date - timedelta(days=days)
         return LocalDate(new_date)
     
-    def sub_months(self, months: int) -> "LocalDate":
+    def sub_months(self, months: int = 1) -> "LocalDate":
         """
         Subtract months from this date.
-        
+
         Args:
-            months: Number of months to subtract
-            
+            months: Number of months to subtract (default: 1)
+
         Returns:
             New LocalDate instance
         """
         year = self._date.year
         month = self._date.month - months
         day = self._date.day
-        
+
         # Handle year rollover
         while month <= 0:
             month += 12
             year -= 1
-        
+
         # Handle day overflow (e.g., Jan 31 - 1 month = Dec 31, not Dec 28)
         max_day = calendar.monthrange(year, month)[1]
         day = min(day, max_day)
-        
+
         return LocalDate(date(year, month, day))
     
-    def sub_years(self, years: int) -> "LocalDate":
+    def sub_years(self, years: int = 1) -> "LocalDate":
         """
         Subtract years from this date.
-        
+
         Args:
-            years: Number of years to subtract
-            
+            years: Number of years to subtract (default: 1)
+
         Returns:
             New LocalDate instance
         """
         year = self._date.year - years
         month = self._date.month
         day = self._date.day
-        
+
         # Handle leap year (Feb 29 -> Feb 28)
         max_day = calendar.monthrange(year, month)[1]
         day = min(day, max_day)
-        
+
         return LocalDate(date(year, month, day))
     
     # ========== Addition Methods ==========
     
-    def add_days(self, days: int) -> "LocalDate":
+    def add_days(self, days: int = 1) -> "LocalDate":
         """
         Add days to this date.
-        
+
         Args:
-            days: Number of days to add
-            
+            days: Number of days to add (default: 1)
+
         Returns:
             New LocalDate instance
         """
         new_date = self._date + timedelta(days=days)
         return LocalDate(new_date)
     
-    def add_months(self, months: int) -> "LocalDate":
+    def add_months(self, months: int = 1) -> "LocalDate":
         """
         Add months to this date.
-        
+
         Args:
-            months: Number of months to add
-            
+            months: Number of months to add (default: 1)
+
         Returns:
             New LocalDate instance
         """
         year = self._date.year
         month = self._date.month + months
         day = self._date.day
-        
+
         # Handle year rollover
         while month > 12:
             month -= 12
             year += 1
-        
+
         # Handle day overflow
         max_day = calendar.monthrange(year, month)[1]
         day = min(day, max_day)
-        
+
         return LocalDate(date(year, month, day))
     
-    def add_years(self, years: int) -> "LocalDate":
+    def add_years(self, years: int = 1) -> "LocalDate":
         """
         Add years to this date.
-        
+
         Args:
-            years: Number of years to add
-            
+            years: Number of years to add (default: 1)
+
         Returns:
             New LocalDate instance
         """
         year = self._date.year + years
         month = self._date.month
         day = self._date.day
-        
+
         # Handle leap year
         max_day = calendar.monthrange(year, month)[1]
         day = min(day, max_day)
-        
+
         return LocalDate(date(year, month, day))
     
     # ========== Start/End of Period Methods ==========
@@ -273,33 +331,33 @@ class LocalDate:
         return self.start_of_week(start_day).add_days(6)
     
     # ========== Property Accessors ==========
-    
-    @property
+
+    @DualAccessor
     def year(self) -> int:
         """Get the year component."""
         return self._date.year
-    
-    @property
+
+    @DualAccessor
     def month(self) -> int:
         """Get the month component (1-12)."""
         return self._date.month
-    
-    @property
+
+    @DualAccessor
     def day(self) -> int:
         """Get the day component (1-31)."""
         return self._date.day
-    
-    @property
+
+    @DualAccessor
     def quarter(self) -> int:
         """Get the quarter (1-4)."""
         return (self._date.month - 1) // 3 + 1
-    
-    @property
+
+    @DualAccessor
     def day_of_week(self) -> int:
         """Get the day of week (0=Monday, 6=Sunday)."""
         return self._date.weekday()
-    
-    @property
+
+    @DualAccessor
     def day_of_year(self) -> int:
         """Get the day of year (1-366)."""
         return self._date.timetuple().tm_yday
@@ -317,6 +375,15 @@ class LocalDate:
             Formatted date string
         """
         return self._date.strftime(fmt)
+    
+    def to_date_string(self) -> str:
+        """
+        Get the date as a string in YYYY-MM-DD format.
+        
+        Returns:
+            Date string in YYYY-MM-DD format
+        """
+        return self.format("%Y-%m-%d")
     
     def to_date(self) -> date:
         """

--- a/src/dbt/adapters/hologres/relation_configs/__init__.py
+++ b/src/dbt/adapters/hologres/relation_configs/__init__.py
@@ -1,5 +1,5 @@
 # Maximum characters in a Hologres identifier (same as PostgreSQL)
-MAX_CHARACTERS_IN_IDENTIFIER = 128
+MAX_CHARACTERS_IN_IDENTIFIER = 90 
 
 from dbt.adapters.hologres.relation_configs.index import (  # noqa: F401
     HologresIndexConfig,

--- a/src/dbt/adapters/hologres/relation_configs/__init__.py
+++ b/src/dbt/adapters/hologres/relation_configs/__init__.py
@@ -1,16 +1,5 @@
 # Maximum characters in a Hologres identifier (same as PostgreSQL)
-MAX_CHARACTERS_IN_IDENTIFIER = 63
-
-from dbt.adapters.hologres.relation_configs.index import (  # noqa: F401
-    HologresIndexConfig,
-    HologresIndexConfigChange,
-)
-from dbt.adapters.hologres.relation_configs.dynamic_table import (  # noqa: F401
-    HologresDynamicTableConfig,
-    HologresDynamicTableConfigChangeCollection,
-)
-# Maximum characters in a Hologres identifier (same as PostgreSQL)
-MAX_CHARACTERS_IN_IDENTIFIER = 63
+MAX_CHARACTERS_IN_IDENTIFIER = 128
 
 from dbt.adapters.hologres.relation_configs.index import (  # noqa: F401
     HologresIndexConfig,

--- a/src/dbt/adapters/hologres/relation_configs/constants.py
+++ b/src/dbt/adapters/hologres/relation_configs/constants.py
@@ -1,4 +1,3 @@
 # Maximum characters in a Hologres identifier (same as PostgreSQL)
-MAX_CHARACTERS_IN_IDENTIFIER = 63
-# Maximum characters in a Hologres identifier (same as PostgreSQL)
-MAX_CHARACTERS_IN_IDENTIFIER = 63
+MAX_CHARACTERS_IN_IDENTIFIER = 90
+

--- a/tests/unit/test_local_date.py
+++ b/tests/unit/test_local_date.py
@@ -40,6 +40,32 @@ class TestLocalDateCreation:
         assert ld.year == 2024
         assert ld.month == 1
         assert ld.day == 15
+
+    def test_from_datetime_string_with_timezone(self):
+        """Test parsing ISO 8601 datetime string with timezone."""
+        # Test with UTC timezone (+00:00)
+        ld = LocalDate("2026-03-17T09:02:12+00:00")
+        assert ld.year == 2026
+        assert ld.month == 3
+        assert ld.day == 17
+
+        # Test with positive timezone offset
+        ld2 = LocalDate("2024-01-15T23:30:00+08:00")
+        assert ld2.year == 2024
+        assert ld2.month == 1
+        assert ld2.day == 15
+
+        # Test with negative timezone offset
+        ld3 = LocalDate("2024-01-15T01:30:00-05:00")
+        assert ld3.year == 2024
+        assert ld3.month == 1
+        assert ld3.day == 15
+
+        # Test with Z (Zulu time, equivalent to +00:00)
+        ld4 = LocalDate("2024-12-31T23:59:59Z")
+        assert ld4.year == 2024
+        assert ld4.month == 12
+        assert ld4.day == 31
     
     def test_from_date_object(self):
         """Test creating from date object."""
@@ -299,6 +325,51 @@ class TestLocalDateProperties:
         assert LocalDate("2024-04-15").quarter == 2
         assert LocalDate("2024-07-15").quarter == 3
         assert LocalDate("2024-10-15").quarter == 4
+
+    def test_dual_access_year(self):
+        """Test year property can be accessed as both attribute and method."""
+        ld = LocalDate("2024-06-15")
+        assert ld.year == 2024  # Attribute access
+        assert ld.year() == 2024  # Method call
+
+    def test_dual_access_month(self):
+        """Test month property can be accessed as both attribute and method."""
+        ld = LocalDate("2024-06-15")
+        assert ld.month == 6  # Attribute access
+        assert ld.month() == 6  # Method call
+
+    def test_dual_access_day(self):
+        """Test day property can be accessed as both attribute and method."""
+        ld = LocalDate("2024-06-15")
+        assert ld.day == 15  # Attribute access
+        assert ld.day() == 15  # Method call
+
+    def test_dual_access_quarter(self):
+        """Test quarter property can be accessed as both attribute and method."""
+        ld = LocalDate("2024-04-15")
+        assert ld.quarter == 2  # Attribute access
+        assert ld.quarter() == 2  # Method call
+
+    def test_dual_access_day_of_week(self):
+        """Test day_of_week property can be accessed as both attribute and method."""
+        ld = LocalDate("2024-03-18")  # Monday
+        assert ld.day_of_week == 0  # Attribute access
+        assert ld.day_of_week() == 0  # Method call
+
+    def test_dual_access_day_of_year(self):
+        """Test day_of_year property can be accessed as both attribute and method."""
+        ld = LocalDate("2024-03-15")
+        # March 15 is the 75th day of 2024 (leap year)
+        expected_day = 75
+        assert ld.day_of_year == expected_day  # Attribute access
+        assert ld.day_of_year() == expected_day  # Method call
+
+    def test_property_in_arithmetic(self):
+        """Test that properties work in arithmetic expressions."""
+        ld = LocalDate("2024-06-15")
+        assert ld.year + 1 == 2025
+        assert ld.month * 2 == 12
+        assert ld.day - 5 == 10
 
 
 class TestLocalDateFormatting:


### PR DESCRIPTION
增强 LocalDate 类以提供更灵活的 API 和更好的时区支持:

- 添加 DualAccessor 描述符,支持属性和方法双重访问方式
  * ld.year 和 ld.year() 均可使用,提高 API 灵活性
  * 适用于所有日期组件属性 (year, month, day, quarter, day_of_week, day_of_year)

- 增强 ISO 8601 时区格式解析能力
  * 支持带时区的时间戳 (如 2024-01-15T10:30:00+08:00)
  * 支持 UTC Zulu 时间格式 (如 2024-12-31T23:59:59Z)
  * 提高与不同时区数据源的兼容性

- 优化方法默认参数
  * 所有 add/sub 方法添加默认值 1,简化常见用法
  * 如 ld.sub_days() 等同于 ld.sub_days(1)

- 新增便捷方法 to_date_string(),返回 YYYY-MM-DD 格式字符串

- 修正 Hologres 标识符最大长度为 90 (从 PostgreSQL 的 63 调整)
  * Hologres 支持更长的标识符名称
  * 提高与 Hologres 的兼容性

此次改进使 LocalDate API 更加灵活和易用,同时增强了与时区数据源的互操作性。